### PR TITLE
Fixes for relation members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ lto = true
 opt-level = 3
 
 [dependencies]
-byteorder = "1.2"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
-num_cpus = "1.8"
+byteorder = "1.3.2"
+flate2 = { version = "1.0.9", features = ["zlib"], default-features = false }
+num_cpus = "1.10.1"
 protobuf_iter = "0.1.1"
+# protobuf_iter = { path = "../rust-protobuf-iter" }

--- a/src/parse/relation.rs
+++ b/src/parse/relation.rs
@@ -43,7 +43,6 @@ pub enum RelationMemberType {
 pub struct RelationMembersIter<'a> {
     roles_sid: PackedIter<'a, PackedVarint, i32>,
     memids: DeltaEncodedIter<'a, PackedVarint, i64>,
-    memid: i64,
     types: PackedIter<'a, PackedVarint, u32>,
     stringtable: &'a [&'a str],
 }
@@ -59,8 +58,7 @@ impl<'a> Iterator for RelationMembersIter<'a> {
             return None
         };
 
-        let memid_delta = self.memids.next()?;
-        self.memid += memid_delta;
+        let memid = self.memids.next()? as u64;
 
         let memtype = match self.types.next() {
             Some(0) => RelationMemberType::Node,
@@ -69,7 +67,7 @@ impl<'a> Iterator for RelationMembersIter<'a> {
             _ => return None,
         };
 
-        Some((role, self.memid as u64, memtype))
+        Some((role, memid, memtype))
     }
 }
 
@@ -101,7 +99,6 @@ impl<'a> Relation<'a> {
             rels_iter: RelationMembersIter {
                 roles_sid: PackedIter::new(&[]),
                 memids: DeltaEncodedIter::new(ParseValue::LengthDelimited(&[])),
-                memid: 0,
                 types: PackedIter::new(&[]),
                 stringtable: &primitive_block.stringtable,
             },


### PR DESCRIPTION
This should fix #2 and fix #3

- The delta iterator already calculated the delta, the library was wrongly accumulating again on top of it.
- The roles_sid are per pbf documentation `int32` signed without zigzag, changing it to `u32` does not fix the issue but mitigates it for most cases.