### PR TITLE
use rust native deflate implementation instead of zlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ opt-level = 3
 
 [dependencies]
 byteorder = "1.2"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
+flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 num_cpus = "1.8"
 protobuf_iter = "0.1.1"


### PR DESCRIPTION
Hi!

can we change that line to be able to use the rust implementation of zip instead of a linked library?

This allows the ability to deploy this package with pyo3 to pypi conforming manylinux.

Here is the pyo3 (pypi) package I've been working on that can be deployed only with this config enabled
https://pypi.org/project/pyosmptparser/
and the source
https://github.com/cualbondi/pyosmptparser

and this is the rust package that uses yours as a dependency
https://github.com/cualbondi/osmptparser

This is the error I get when trying to use `pyo3-pack deploy` command
```
$ pyo3-pack deploy
   ...
    Finished release [optimized] target(s) in 1m 04s
Your library is not manylinux compliant because it links the following forbidden libraries: ["libz.so.1"]
Failed to ensure manylinux compliance
```
And here is also a link to the doc of the config I would like to change in this Pull Request
https://github.com/alexcrichton/flate2-rs

I ran some tests and all works just fine!